### PR TITLE
fix(qpa): turn off debug logging by default

### DIFF
--- a/epaperevdevkeyboardhandler.cpp
+++ b/epaperevdevkeyboardhandler.cpp
@@ -70,8 +70,8 @@
 
 QT_BEGIN_NAMESPACE
 
-Q_LOGGING_CATEGORY(EpaperEvdevKeyboardLog, "rm.epaperkeyboardhandler")
-Q_LOGGING_CATEGORY(EpaperEvdevKeyboardMapLog, "rm.epaperkeyboardhandler.map")
+Q_LOGGING_CATEGORY(EpaperEvdevKeyboardLog, "rm.epaperkeyboardhandler", QtWarningMsg)
+Q_LOGGING_CATEGORY(EpaperEvdevKeyboardMapLog, "rm.epaperkeyboardhandler.map", QtWarningMsg)
 
 namespace {
 QSettings const qtSettings("remarkable", "xochitl");


### PR DESCRIPTION
overly verbose, and not often necessary, so shut it up.